### PR TITLE
feat: improve homepage with navigation cards

### DIFF
--- a/cambio-aceite.html
+++ b/cambio-aceite.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cambio de aceite paso a paso</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;margin:40px;padding:0;color:#1a1a1a}
+    a{color:#0d6efd;text-decoration:none}
+  </style>
+</head>
+<body>
+  <h1>Cambio de aceite paso a paso</h1>
+  <p>Contenido en construcción.</p>
+  <p><a href="index.html">Volver al inicio</a></p>
+</body>
+</html>

--- a/cambio-filtro-aceite.html
+++ b/cambio-filtro-aceite.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cambio de filtro de aceite</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;margin:40px;padding:0;color:#1a1a1a}
+    a{color:#0d6efd;text-decoration:none}
+  </style>
+</head>
+<body>
+  <h1>Cambio de filtro de aceite</h1>
+  <p>Contenido en construcción.</p>
+  <p><a href="index.html">Volver al inicio</a></p>
+</body>
+</html>

--- a/finder.html
+++ b/finder.html
@@ -5,30 +5,31 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Asesor de Aceite para tu Coche</title>
   <style>
-    :root{--bg:#0b1020;--card:#111833;--muted:#8ea0c3;--text:#e9eefb;--accent:#5b8cff}
     *{box-sizing:border-box}
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:linear-gradient(120deg,#0b1020,#0a1533);color:var(--text)}
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:#f5f6fa;color:#1a1a1a}
+    a{text-decoration:none}
     .wrap{max-width:1100px;margin:40px auto;padding:0 16px}
     header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}
     h1{font-weight:800;letter-spacing:.2px;margin:0;font-size:clamp(22px,2.8vw,34px)}
-    .card{background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+    .card{background:#fff;border-radius:12px;box-shadow:0 2px 10px rgba(0,0,0,.04)}
     .p20{padding:20px}
-    label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
-    input,select{width:100%;padding:12px;border-radius:12px;border:1px solid rgba(255,255,255,.08);background:#0f1530;color:var(--text)}
-    input:focus,select:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(91,140,255,.15)}
+    label{display:block;font-size:13px;color:#444;margin-bottom:6px}
+    input,select{width:100%;padding:12px;border-radius:12px;border:1px solid #ccc;background:#fff;color:#1a1a1a}
+    input:focus,select:focus{border-color:#0d6efd;box-shadow:0 0 0 3px rgba(13,110,253,.15);outline:none}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
     .row3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
-    .btn{appearance:none;border:0;background:var(--accent);color:#fff;padding:12px 16px;border-radius:12px;font-weight:700;cursor:pointer}
-    .btn.secondary{background:#1c254a}
-    .muted{color:var(--muted);font-size:13px}
-    .badge{display:inline-flex;gap:6px;background:#0e1a3d;border:1px solid rgba(255,255,255,.08);padding:6px 10px;border-radius:999px;font-size:12px;color:#00EAFF}
+    .btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600;border:none;cursor:pointer}
+    .btn.primary{background:#0d6efd;color:#fff}
+    .btn.secondary{border:2px solid #0d6efd;color:#0d6efd;background:transparent}
+    .muted{color:#555;font-size:13px}
+    .badge{display:inline-flex;gap:6px;background:#e9ecef;padding:6px 10px;border-radius:999px;font-size:12px;color:#0d6efd}
     .kvs{display:flex;flex-wrap:wrap;gap:10px}
-    .hr{height:1px;background:rgba(255,255,255,.08);margin:14px 0}
+    .hr{height:1px;background:#e9ecef;margin:14px 0}
     .table{width:100%;border-collapse:collapse}
-    .table th,.table td{border-bottom:1px solid rgba(255,255,255,.08);padding:10px;text-align:left;font-size:14px}
-    .table th{color:#bcd0ff}
-    .hint{font-size:12px;color:#cbd5ff}
-    @media (max-width:860px){.row,.row3{grid-template-columns:1fr}}
+    .table th,.table td{border-bottom:1px solid #e9ecef;padding:10px;text-align:left;font-size:14px}
+    .table th{color:#444}
+    .hint{font-size:12px;color:#666}
+    @media(max-width:860px){.row,.row3{grid-template-columns:1fr}}
   </style>
 </head>
 <body>
@@ -108,7 +109,7 @@
         </div>
       </div>
       <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:10px">
-        <button class="btn" id="btnRecommend">Recomendar aceite</button>
+        <button class="btn primary" id="btnRecommend">Recomendar aceite</button>
         <button class="btn secondary" id="btnReset">Limpiar</button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,24 +1,58 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bienvenido - Asesor de Aceite</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Holiday - Asesor de Aceite</title>
   <style>
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:linear-gradient(120deg,#0b1020,#0a1533);color:#e9eefb;display:flex;align-items:center;justify-content:center;height:100vh;text-align:center}
-    .cta{margin-top:30px}
-    a.button{display:inline-block;padding:12px 20px;background:#5b8cff;color:#fff;text-decoration:none;border-radius:12px;font-weight:700}
-    h1{font-size:clamp(26px,5vw,40px);margin-bottom:16px}
-    p{max-width:600px;margin:0 auto 20px;color:#8ea0c3}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:#f5f6fa;color:#1a1a1a}
+    a{text-decoration:none}
+    .hero{max-width:1100px;margin:40px auto;padding:20px;background:#fff;border-radius:16px;display:flex;align-items:center;gap:30px;box-shadow:0 4px 20px rgba(0,0,0,.05)}
+    .hero img{width:50%;border-radius:12px;object-fit:cover}
+    .hero h1{margin-top:0;margin-bottom:12px;font-size:clamp(26px,5vw,42px)}
+    .hero p{margin-top:0;margin-bottom:20px;color:#444}
+    .btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600}
+    .btn.primary{background:#0d6efd;color:#fff}
+    .btn.secondary{border:2px solid #0d6efd;color:#0d6efd;margin-left:10px}
+    .section{max-width:1100px;margin:60px auto;padding:0 20px}
+    .cards{display:flex;flex-wrap:wrap;gap:20px;margin-top:30px}
+    .card{background:#fff;border-radius:12px;padding:20px;box-shadow:0 2px 10px rgba(0,0,0,.04);flex:1;min-width:250px}
+    .card h3{margin-top:0;margin-bottom:12px}
+    .card p{margin-top:0;margin-bottom:20px;color:#555}
+    @media(max-width:860px){.hero{flex-direction:column}.hero img{width:100%}}
   </style>
 </head>
 <body>
-  <main>
-    <h1>Asesor de Aceite para tu Coche</h1>
-    <p>Descubre rápidamente qué lubricante necesita tu vehículo según marca, modelo, año y condiciones de uso. Nuestro asistente utiliza una base de datos simplificada ACEA/OEM para orientarte.</p>
-    <div class="cta">
-      <a class="button" href="finder.html">Comenzar</a>
+  <section class="hero">
+    <div class="hero-text">
+      <h1>Holiday</h1>
+      <p>Guías técnicas, especificaciones y procedimientos claros para cuidar el motor de tu vehículo. Contenido imparcial y verificable.</p>
+      <a href="finder.html" class="btn primary">Comenzar: cambio de aceite</a>
+      <a href="#" class="btn secondary">Descargar checklist</a>
     </div>
-  </main>
+    <img src="https://images.unsplash.com/photo-1503376780353-7e6692767b70?auto=format&fit=crop&w=720&q=80" alt="Auto deportivo" />
+  </section>
+
+  <section class="section">
+    <h2>Procedimientos esenciales</h2>
+    <div class="cards">
+      <article class="card">
+        <h3>Cambio de aceite paso a paso</h3>
+        <p>Secuencia técnica, herramientas y par de apriete para un correcto servicio.</p>
+        <a href="cambio-aceite.html" class="btn primary">Ver guía</a>
+      </article>
+      <article class="card">
+        <h3>Cambio de filtro de aceite</h3>
+        <p>Cuándo y cómo sustituir el elemento filtrante y proteger el motor.</p>
+        <a href="cambio-filtro-aceite.html" class="btn primary">Ver guía</a>
+      </article>
+      <article class="card">
+        <h3>Reciclaje de aceite usado</h3>
+        <p>Normativa básica y puntos de recogida para un descarte seguro.</p>
+        <a href="reciclaje-aceite.html" class="btn primary">Ver guía</a>
+      </article>
+    </div>
+  </section>
 </body>
 </html>

--- a/reciclaje-aceite.html
+++ b/reciclaje-aceite.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reciclaje de aceite usado</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;margin:40px;padding:0;color:#1a1a1a}
+    a{color:#0d6efd;text-decoration:none}
+  </style>
+</head>
+<body>
+  <h1>Reciclaje de aceite usado</h1>
+  <p>Contenido en construcción.</p>
+  <p><a href="index.html">Volver al inicio</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Redesign index with hero section and navigation cards linking to guides
- Add placeholder guide pages for oil change, filter change, and oil recycling
- Align finder page styling with homepage theme

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fd96db3c83319e3e888049244507