### PR TITLE
Align finder page styling with index design

### DIFF
--- a/finder.html
+++ b/finder.html
@@ -5,29 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Asesor de Aceite para tu Coche</title>
   <style>
-    :root{--bg:#0b1020;--card:#111833;--muted:#8ea0c3;--text:#e9eefb;--accent:#5b8cff}
+    :root{--bg:#f5f6fa;--card:#fff;--muted:#555;--text:#1a1a1a;--accent:#0d6efd}
     *{box-sizing:border-box}
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:linear-gradient(120deg,#0b1020,#0a1533);color:var(--text)}
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text)}
     .wrap{max-width:1100px;margin:40px auto;padding:0 16px}
     header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}
     h1{font-weight:800;letter-spacing:.2px;margin:0;font-size:clamp(22px,2.8vw,34px)}
-    .card{background:var(--card);border:1px solid rgba(255,255,255,.08);border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+    .card{background:var(--card);border:1px solid rgba(0,0,0,.05);border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.05)}
     .p20{padding:20px}
     label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
-    input,select{width:100%;padding:12px;border-radius:12px;border:1px solid rgba(255,255,255,.08);background:#0f1530;color:var(--text)}
-    input:focus,select:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(91,140,255,.15)}
+    input,select{width:100%;padding:12px;border-radius:12px;border:1px solid rgba(0,0,0,.1);background:#fff;color:var(--text)}
+    input:focus,select:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(13,110,253,.15)}
     .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
     .row3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
-    .btn{appearance:none;border:0;background:var(--accent);color:#fff;padding:12px 16px;border-radius:12px;font-weight:700;cursor:pointer}
-    .btn.secondary{background:#f5f6fa}
+    .btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600;cursor:pointer;border:0}
+    .btn.primary{background:var(--accent);color:#fff}
+    .btn.secondary{border:2px solid var(--accent);color:var(--accent);background:transparent}
     .muted{color:var(--muted);font-size:13px}
-    .badge{display:inline-flex;gap:6px;background:#f5f6fa;border:1px solid rgba(255,255,255,.08);padding:6px 10px;border-radius:999px;font-size:12px;color:#FFFFFF}
+    .badge{display:inline-flex;gap:6px;background:var(--bg);border:1px solid rgba(0,0,0,.1);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--text)}
     .kvs{display:flex;flex-wrap:wrap;gap:10px}
-    .hr{height:1px;background:rgba(255,255,255,.08);margin:14px 0}
+    .hr{height:1px;background:rgba(0,0,0,.08);margin:14px 0}
     .table{width:100%;border-collapse:collapse}
-    .table th,.table td{border-bottom:1px solid rgba(255,255,255,.08);padding:10px;text-align:left;font-size:14px}
-    .table th{color:#000000}
-    .hint{font-size:12px;color:#000000}
+    .table th,.table td{border-bottom:1px solid rgba(0,0,0,.08);padding:10px;text-align:left;font-size:14px}
+    .table th{color:var(--text)}
+    .hint{font-size:12px;color:var(--muted)}
     @media (max-width:860px){.row,.row3{grid-template-columns:1fr}}
   </style>
 </head>
@@ -108,7 +109,7 @@
         </div>
       </div>
       <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:10px">
-        <button class="btn" id="btnRecommend">Recomendar aceite</button>
+        <button class="btn primary" id="btnRecommend">Recomendar aceite</button>
         <button class="btn secondary" id="btnReset">Limpiar</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adopted light theme, card, input, badge and button styles in `finder.html` to match `index.html`.
- Marked main action button as `primary` so it uses the new styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b721d82d848331916afe63f00be87c