### PR TITLE
Separate styles into dedicated stylesheet

### DIFF
--- a/finder.html
+++ b/finder.html
@@ -5,31 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Asesor de Aceite para tu Coche</title>
   <link rel="stylesheet" href="style.css" />
-  <style>
-    :root{--bg:#f5f6fa;--card:#fff;--muted:#555;--text:#1a1a1a;--accent:#0d6efd}
-    .wrap{max-width:1100px;margin:40px auto;padding:0 16px}
-    header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}
-    h1{font-weight:800;letter-spacing:.2px;margin:0;font-size:clamp(22px,2.8vw,34px)}
-    .card{background:var(--card);border:1px solid rgba(0,0,0,.05);border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.05)}
-    .p20{padding:20px}
-    label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
-    input,select{width:100%;padding:12px;border-radius:12px;border:1px solid rgba(0,0,0,.1);background:#fff;color:var(--text)}
-    input:focus,select:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(13,110,253,.15)}
-    .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-    .row3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
-    .btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600;cursor:pointer;border:0}
-    .btn.primary{background:var(--accent);color:#fff}
-    .btn.secondary{border:2px solid var(--accent);color:var(--accent);background:transparent}
-    .muted{color:var(--muted);font-size:13px}
-    .badge{display:inline-flex;gap:6px;background:var(--bg);border:1px solid rgba(0,0,0,.1);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--text)}
-    .kvs{display:flex;flex-wrap:wrap;gap:10px}
-    .hr{height:1px;background:rgba(0,0,0,.08);margin:14px 0}
-    .table{width:100%;border-collapse:collapse}
-    .table th,.table td{border-bottom:1px solid rgba(0,0,0,.08);padding:10px;text-align:left;font-size:14px}
-    .table th{color:var(--text)}
-    .hint{font-size:12px;color:var(--muted)}
-    @media (max-width:860px){.row,.row3{grid-template-columns:1fr}}
-  </style>
 </head>
 <body>
   <div class="wrap">
@@ -42,7 +17,7 @@
       </div>
     </header>
 
-    <div class="card p20" style="margin-bottom:22px">
+    <div class="card p20 mb-22">
       <div class="row">
         <div>
           <label>Marca</label>
@@ -107,7 +82,7 @@
           <input id="oem" placeholder="Separadas por coma: VW 504.00/507.00, ACEA C3…" />
         </div>
       </div>
-      <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:10px">
+      <div class="button-row">
         <button class="btn primary" id="btnRecommend">Recomendar aceite</button>
         <button class="btn secondary" id="btnReset">Limpiar</button>
       </div>
@@ -116,11 +91,11 @@
     <section class="card p20 result" id="result" hidden>
       <div class="kvs" id="chips"></div>
       <div class="hr"></div>
-      <div id="carLine" class="muted" style="margin-bottom:10px"></div>
+      <div id="carLine" class="muted mb-10"></div>
       <div id="explain" class="hint"></div>
     </section>
 
-    <section class="card p20" style="margin-top:22px">
+    <section class="card p20 mt-22">
       <details>
         <summary><strong>Base de datos incluida</strong></summary>
         <p class="muted">La tabla se alimenta de todos los CARS (base + extra).</p>
@@ -128,7 +103,7 @@
       </details>
     </section>
 
-    <section class="card p20" style="margin-top:22px">
+    <section class="card p20 mt-22">
       <details>
         <summary><strong>Catálogo de aceites (demo)(enlaces Amazón Afiliados)</strong></summary>
         <table class="table" id="oilTable"></table>

--- a/index.html
+++ b/index.html
@@ -5,21 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Holiday - Asesor de Aceite</title>
   <link rel="stylesheet" href="style.css" />
-  <style>
-    .hero{max-width:1100px;margin:40px auto;padding:20px;background:#fff;border-radius:16px;display:flex;align-items:center;gap:30px;box-shadow:0 4px 20px rgba(0,0,0,.05)}
-    .hero img{width:50%;border-radius:12px;object-fit:cover}
-    .hero h1{margin-top:0;margin-bottom:12px;font-size:clamp(26px,5vw,42px)}
-    .hero p{margin-top:0;margin-bottom:20px;color:#444}
-    .btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600}
-    .btn.primary{background:#0d6efd;color:#fff}
-    .btn.secondary{border:2px solid #0d6efd;color:#0d6efd;margin-left:10px}
-    .section{max-width:1100px;margin:60px auto;padding:0 20px}
-    .cards{display:flex;flex-wrap:wrap;gap:20px;margin-top:30px}
-    .card{background:#fff;border-radius:12px;padding:20px;box-shadow:0 2px 10px rgba(0,0,0,.04);flex:1;min-width:250px}
-    .card h3{margin-top:0;margin-bottom:12px}
-    .card p{margin-top:0;margin-bottom:20px;color:#555}
-    @media(max-width:860px){.hero{flex-direction:column}.hero img{width:100%}}
-  </style>
 </head>
 <body>
   <section class="hero">

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
+:root{--bg:#f5f6fa;--card:#fff;--muted:#555;--text:#1a1a1a;--accent:#0d6efd}
 *{box-sizing:border-box}
-body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:#f5f6fa;color:#1a1a1a;line-height:1.6}
+body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
 a{color:#0d6efd;text-decoration:none}
 .layout{max-width:1200px;margin:40px auto;display:flex;gap:40px;padding:0 20px}
 .content{flex:1;background:#fff;padding:30px;border-radius:16px;box-shadow:0 4px 20px rgba(0,0,0,.05)}
@@ -7,4 +8,39 @@ a{color:#0d6efd;text-decoration:none}
 .sidebar h2{margin-top:0;font-size:18px}
 .intro{background:#f0f2f5;padding:15px;border-radius:8px;list-style:disc;margin:20px 0}
 .intro li{margin-bottom:8px}
-h1{margin-top:0}
+h1{margin-top:0;font-weight:800;letter-spacing:.2px;font-size:clamp(22px,2.8vw,34px)}
+.hero{max-width:1100px;margin:40px auto;padding:20px;background:#fff;border-radius:16px;display:flex;align-items:center;gap:30px;box-shadow:0 4px 20px rgba(0,0,0,.05)}
+.hero img{width:50%;border-radius:12px;object-fit:cover}
+.hero h1{margin-bottom:12px;font-size:clamp(26px,5vw,42px)}
+.hero p{margin-top:0;margin-bottom:20px;color:#444}
+.btn{display:inline-block;padding:12px 20px;border-radius:10px;font-weight:600;cursor:pointer;border:0}
+.btn.primary{background:var(--accent);color:#fff}
+.btn.secondary{border:2px solid var(--accent);color:var(--accent);background:transparent;margin-left:10px}
+.section{max-width:1100px;margin:60px auto;padding:0 20px}
+.cards{display:flex;flex-wrap:wrap;gap:20px;margin-top:30px}
+.cards .card{background:#fff;border-radius:12px;padding:20px;box-shadow:0 2px 10px rgba(0,0,0,.04);flex:1;min-width:250px}
+.cards .card h3{margin-top:0;margin-bottom:12px}
+.cards .card p{margin-top:0;margin-bottom:20px;color:#555}
+@media(max-width:860px){.hero{flex-direction:column}.hero img{width:100%}}
+.wrap{max-width:1100px;margin:40px auto;padding:0 16px}
+header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}
+.wrap .card{background:var(--card);border:1px solid rgba(0,0,0,.05);border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.05)}
+.p20{padding:20px}
+label{display:block;font-size:13px;color:var(--muted);margin-bottom:6px}
+input,select{width:100%;padding:12px;border-radius:12px;border:1px solid rgba(0,0,0,.1);background:#fff;color:var(--text)}
+input:focus,select:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(13,110,253,.15)}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.row3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+.muted{color:var(--muted);font-size:13px}
+.badge{display:inline-flex;gap:6px;background:var(--bg);border:1px solid rgba(0,0,0,.1);padding:6px 10px;border-radius:999px;font-size:12px;color:var(--text)}
+.kvs{display:flex;flex-wrap:wrap;gap:10px}
+.hr{height:1px;background:rgba(0,0,0,.08);margin:14px 0}
+.table{width:100%;border-collapse:collapse}
+.table th,.table td{border-bottom:1px solid rgba(0,0,0,.08);padding:10px;text-align:left;font-size:14px}
+.table th{color:var(--text)}
+.hint{font-size:12px;color:var(--muted)}
+@media (max-width:860px){.row,.row3{grid-template-columns:1fr}}
+.mb-22{margin-bottom:22px}
+.mt-22{margin-top:22px}
+.mb-10{margin-bottom:10px}
+.button-row{display:flex;justify-content:flex-end;margin-top:10px}


### PR DESCRIPTION
## Summary
- Move inline styles from `index.html` and `finder.html` into `style.css`
- Add utility classes for spacing and button layout
- Simplify HTML by removing inline and embedded CSS

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1ecd0688331b79ba589418ab4af