### PR TITLE
Add sitemap.xml for OilAdvisor

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://oiladvisor.github.io/OilAdvisor/</loc>
+  </url>
+  <url>
+    <loc>https://oiladvisor.github.io/OilAdvisor/cambio-aceite.html</loc>
+  </url>
+  <url>
+    <loc>https://oiladvisor.github.io/OilAdvisor/cambio-filtro-aceite.html</loc>
+  </url>
+  <url>
+    <loc>https://oiladvisor.github.io/OilAdvisor/finder.html</loc>
+  </url>
+  <url>
+    <loc>https://oiladvisor.github.io/OilAdvisor/reciclaje-aceite.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- create sitemap.xml listing site pages to improve SEO

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('sitemap.xml')
print('OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb2c05d71883318b028f62f49bf8a4